### PR TITLE
fix: Implement Avellaneda-Stoikov market-making strategy

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,2 @@
+from .strategy import Strategy
+from . import strategies

--- a/src/agents/strategies/__init__.py
+++ b/src/agents/strategies/__init__.py
@@ -1,0 +1,5 @@
+"""
+This module contains implementations of various market-making and trading strategies.
+"""
+
+from .avellaneda_stoikov import AvellanedaStoikovConfig, AvellanedaStoikovStrategy

--- a/src/agents/strategies/avellaneda_stoikov.py
+++ b/src/agents/strategies/avellaneda_stoikov.py
@@ -1,0 +1,156 @@
+import math
+from dataclasses import dataclass
+from typing import Dict, Any
+
+from src.agents.strategy import Strategy
+
+@dataclass
+class AvellanedaStoikovConfig:
+    """Configuration for the Avellaneda-Stoikov market-making strategy."""
+    gamma: float = 0.1             # Risk aversion parameter (gamma > 0)
+    sigma: float = 0.01            # Volatility estimate (standard deviation of log returns)
+    k: float = 1.0                 # Market order arrival intensity parameter (k > 0)
+    time_horizon_seconds: float = 3600.0 # Total trading horizon in seconds (T)
+    min_spread: float = 0.0001     # Minimum allowed half-spread to prevent zero or negative spreads
+    order_size: float = 1.0        # Default order size for bids/asks
+    max_inventory: int = 100       # Maximum absolute inventory allowed (to limit risk)
+
+class AvellanedaStoikovStrategy(Strategy):
+    """
+    Implements the Avellaneda-Stoikov optimal market-making strategy.
+
+    This strategy aims to maximize the market maker's utility, which balances
+    profit from quoted spreads and the cost of holding inventory risk, over a
+    given trading horizon. It dynamically adjusts bid and ask quotes based on
+    current inventory, time remaining, market volatility, and risk aversion.
+
+    Key Equations (from Avellaneda & Stoikov (2008), Section 3.2):
+    - Reservation Price (r_t):
+      r_t = S_t - q * gamma * sigma^2 * (T - t)
+
+    - Half-Spread (delta_A):
+      delta_A = (1/gamma) * log(1 + gamma / k)
+
+    Where:
+    - S_t: Current mid-price
+    - q: Current inventory (positive for long, negative for short)
+    - gamma: Risk aversion parameter (how much the MM penalizes inventory risk)
+    - sigma: Volatility estimate (standard deviation of asset returns)
+    - T: Total trading horizon (time until the strategy concludes)
+    - t: Current time elapsed since the start of the horizon
+    - k: Market order arrival intensity parameter (related to how often market orders arrive)
+
+    Optimal Bid Price: p_b* = r_t - delta_A
+    Optimal Ask Price: p_a* = r_t + delta_A
+
+    Note: The time 't' should be interpreted as time elapsed, so `time_remaining = T - t`.
+    The `market_data` dictionary is expected to contain at least 'mid_price'.
+    """
+
+    def __init__(self, config: AvellanedaStoikovConfig):
+        """
+        Initializes the Avellaneda-Stoikov strategy with the given configuration.
+
+        Args:
+            config (AvellanedaStoikovConfig): Configuration object for the strategy.
+        """
+        super().__init__(config)
+        self.config: AvellanedaStoikovConfig = config
+
+        # Validate initial configuration parameters
+        if not (self.config.gamma > 0 and self.config.sigma >= 0 and self.config.k > 0 and self.config.time_horizon_seconds > 0):
+            raise ValueError("Config parameters gamma, sigma, k, and time_horizon_seconds must be positive (sigma can be zero for zero volatility).")
+        if self.config.min_spread < 0:
+            raise ValueError("min_spread cannot be negative.")
+        if self.config.order_size <= 0:
+            raise ValueError("order_size must be positive.")
+        if self.config.max_inventory < 0:
+            raise ValueError("max_inventory cannot be negative.")
+
+
+    def generate_orders(self, market_data: Dict[str, Any], current_inventory: float, current_time: float) -> Dict[str, Any]:
+        """
+        Generates bid and ask prices based on the Avellaneda-Stoikov model.
+
+        Args:
+            market_data (Dict[str, Any]): Dictionary containing market information,
+                                         e.g., {'mid_price': 100.0}.
+            current_inventory (float): Current inventory of the asset.
+                                       Positive for long, negative for short.
+            current_time (float): Current time in seconds, relative to the start
+                                  of the trading horizon (0 to T).
+
+        Returns:
+            Dict[str, Any]: A dictionary containing 'bid_price', 'ask_price',
+                            'bid_amount', 'ask_amount'.
+                            Prices can be None if no order is to be placed.
+        """
+        mid_price = market_data.get('mid_price')
+        if mid_price is None:
+            raise ValueError("Market data must contain 'mid_price'.")
+
+        gamma = self.config.gamma
+        sigma = self.config.sigma
+        k = self.config.k
+        T = self.config.time_horizon_seconds
+        order_size = self.config.order_size
+        min_spread = self.config.min_spread
+        max_inventory = self.config.max_inventory
+
+        if current_time < 0:
+            raise ValueError("Current time cannot be negative.")
+
+        time_remaining = T - current_time
+
+        # If at or past the end of the trading horizon, liquidate inventory.
+        # This simplifies the end-of-period behavior.
+        if time_remaining <= 0:
+            if abs(current_inventory) > 0:
+                # Attempt to liquidate inventory at mid-price +/- min_spread
+                bid_price = mid_price - min_spread if current_inventory < 0 else None
+                ask_price = mid_price + min_spread if current_inventory > 0 else None
+                bid_amount = abs(current_inventory) if bid_price is not None else 0.0
+                ask_amount = abs(current_inventory) if ask_price is not None else 0.0
+                return {
+                    'bid_price': bid_price,
+                    'ask_price': ask_price,
+                    'bid_amount': bid_amount,
+                    'ask_amount': ask_amount
+                }
+            # No inventory and time expired, so no quotes
+            return {'bid_price': None, 'ask_price': None, 'bid_amount': 0.0, 'ask_amount': 0.0}
+
+        # If inventory exceeds max_inventory, only place orders to reduce the excess.
+        # This is a risk management override.
+        if current_inventory > max_inventory:
+            return {'bid_price': None, 'ask_price': mid_price + min_spread, 'bid_amount': 0.0, 'ask_amount': current_inventory - max_inventory}
+        elif current_inventory < -max_inventory:
+            return {'bid_price': mid_price - min_spread, 'ask_price': None, 'bid_amount': abs(current_inventory) - max_inventory, 'ask_amount': 0.0}
+
+        # 1. Calculate the reservation price adjustment due to inventory risk
+        # This term shifts the mid-price based on inventory and risk aversion.
+        # A positive inventory (long) reduces the reservation price, encouraging selling.
+        # A negative inventory (short) increases the reservation price, encouraging buying.
+        inventory_risk_adjustment = current_inventory * gamma * sigma**2 * time_remaining
+        reservation_price = mid_price - inventory_risk_adjustment
+
+        # 2. Calculate the optimal half-spread
+        # This term is independent of inventory and time remaining in this formulation.
+        # It balances the profit from order execution against the probability of order not being filled.
+        # Ensure the log argument is positive. Given k > 0 and gamma > 0, 1 + gamma / k will always be > 1.
+        optimal_half_spread = (1 / gamma) * math.log(1 + gamma / k)
+
+        # Apply minimum spread requirement to prevent quotes that are too tight
+        optimal_half_spread = max(optimal_half_spread, min_spread)
+
+        # Calculate optimal bid and ask prices based on reservation price and half-spread
+        bid_price = reservation_price - optimal_half_spread
+        ask_price = reservation_price + optimal_half_spread
+
+        return {
+            'bid_price': bid_price,
+            'ask_price': ask_price,
+            'bid_amount': order_size,
+            'ask_amount': order_size
+        }
+

--- a/src/agents/strategy.py
+++ b/src/agents/strategy.py
@@ -1,0 +1,41 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+class Strategy(ABC):
+    """Base class for all trading strategies.
+
+    Provides an abstract interface that all concrete strategies should implement.
+    Strategies are responsible for generating trading orders based on market data,
+    current inventory, and time.
+    """
+
+    def __init__(self, config: Any):
+        """
+        Initializes the strategy with a given configuration.
+
+        Args:
+            config (Any): A dataclass or dictionary holding strategy-specific parameters.
+        """
+        self.config = config
+
+    @abstractmethod
+    def generate_orders(self, market_data: Dict[str, Any], current_inventory: float, current_time: float) -> Dict[str, Any]:
+        """
+        Generates trading orders (bid/ask prices and amounts) based on the current market state.
+
+        Args:
+            market_data (Dict[str, Any]): A dictionary containing relevant market information,
+                                         e.g., {'mid_price': 100.0, 'timestamp': ...}.
+            current_inventory (float): The current inventory of the asset the strategy is trading.
+                                       Positive for long positions, negative for short positions.
+            current_time (float): The current simulation or real-world time, typically in seconds
+                                  relative to a starting point or absolute timestamp.
+
+        Returns:
+            Dict[str, Any]: A dictionary containing the generated orders.
+                            Expected keys: 'bid_price', 'ask_price', 'bid_amount', 'ask_amount'.
+                            If a price is None, it implies no order is placed on that side.
+                            Amounts should be positive floats.
+        """
+        pass
+

--- a/tests/unit/agents/strategies/test_avellaneda_stoikov.py
+++ b/tests/unit/agents/strategies/test_avellaneda_stoikov.py
@@ -1,0 +1,269 @@
+import unittest
+import math
+from src.agents.strategies.avellaneda_stoikov import AvellanedaStoikovConfig, AvellanedaStoikovStrategy
+
+class TestAvellanedaStoikovStrategy(unittest.TestCase):
+
+    def setUp(self):
+        self.default_config = AvellanedaStoikovConfig(
+            gamma=0.1,
+            sigma=0.01,
+            k=1.0,
+            time_horizon_seconds=3600.0, # 1 hour
+            min_spread=0.0001,
+            order_size=1.0,
+            max_inventory=100
+        )
+        self.mid_price = 100.0
+
+    def test_initial_state_zero_inventory(self):
+        """Test with zero inventory at the start of the horizon, checking base spread."""
+        strategy = AvellanedaStoikovStrategy(self.default_config)
+        market_data = {'mid_price': self.mid_price}
+        current_inventory = 0.0
+        current_time = 0.0
+
+        orders = strategy.generate_orders(market_data, current_inventory, current_time)
+
+        # Expected calculations:
+        # time_remaining = 3600 - 0 = 3600
+        # inventory_risk_adjustment = 0 * gamma * sigma^2 * time_remaining = 0
+        # reservation_price = mid_price - 0 = 100.0
+        # optimal_half_spread = (1/gamma) * log(1 + gamma / k)
+        expected_half_spread = (1 / self.default_config.gamma) * math.log(1 + self.default_config.gamma / self.default_config.k)
+        expected_half_spread = max(expected_half_spread, self.default_config.min_spread) # Apply min_spread
+
+        expected_bid = self.mid_price - expected_half_spread
+        expected_ask = self.mid_price + expected_half_spread
+
+        self.assertAlmostEqual(orders['bid_price'], expected_bid, places=8)
+        self.assertAlmostEqual(orders['ask_price'], expected_ask, places=8)
+        self.assertEqual(orders['bid_amount'], self.default_config.order_size)
+        self.assertEqual(orders['ask_amount'], self.default_config.order_size)
+
+    def test_positive_inventory(self):
+        """Test with positive inventory, should shift quotes lower to encourage selling."""
+        strategy = AvellanedaStoikovStrategy(self.default_config)
+        market_data = {'mid_price': self.mid_price}
+        current_inventory = 10.0
+        current_time = 0.0
+
+        orders = strategy.generate_orders(market_data, current_inventory, current_time)
+
+        # Expected calculations:
+        # time_remaining = 3600
+        # inventory_risk_adjustment = 10 * 0.1 * (0.01)^2 * 3600 = 0.36
+        # reservation_price = 100.0 - 0.36 = 99.64
+        # optimal_half_spread (same as before)
+        expected_half_spread = (1 / self.default_config.gamma) * math.log(1 + self.default_config.gamma / self.default_config.k)
+        expected_half_spread = max(expected_half_spread, self.default_config.min_spread)
+
+        expected_reservation_price = self.mid_price - current_inventory * self.default_config.gamma * \
+                                     self.default_config.sigma**2 * (self.default_config.time_horizon_seconds - current_time)
+        expected_bid = expected_reservation_price - expected_half_spread
+        expected_ask = expected_reservation_price + expected_half_spread
+
+        self.assertAlmostEqual(orders['bid_price'], expected_bid, places=8)
+        self.assertAlmostEqual(orders['ask_price'], expected_ask, places=8)
+        self.assertLess(orders['bid_price'], self.mid_price)
+        self.assertLess(orders['ask_price'], self.mid_price + expected_half_spread * 2) # Overall spread shifted down
+
+    def test_negative_inventory(self):
+        """Test with negative inventory, should shift quotes higher to encourage buying."""
+        strategy = AvellanedaStoikovStrategy(self.default_config)
+        market_data = {'mid_price': self.mid_price}
+        current_inventory = -10.0
+        current_time = 0.0
+
+        orders = strategy.generate_orders(market_data, current_inventory, current_time)
+
+        # Expected calculations:
+        # time_remaining = 3600
+        # inventory_risk_adjustment = -10 * 0.1 * (0.01)^2 * 3600 = -0.36
+        # reservation_price = 100.0 - (-0.36) = 100.36
+        # optimal_half_spread (same as before)
+        expected_half_spread = (1 / self.default_config.gamma) * math.log(1 + self.default_config.gamma / self.default_config.k)
+        expected_half_spread = max(expected_half_spread, self.default_config.min_spread)
+
+        expected_reservation_price = self.mid_price - current_inventory * self.default_config.gamma * \
+                                     self.default_config.sigma**2 * (self.default_config.time_horizon_seconds - current_time)
+        expected_bid = expected_reservation_price - expected_half_spread
+        expected_ask = expected_reservation_price + expected_half_spread
+
+        self.assertAlmostEqual(orders['bid_price'], expected_bid, places=8)
+        self.assertAlmostEqual(orders['ask_price'], expected_ask, places=8)
+        self.assertGreater(orders['ask_price'], self.mid_price)
+        self.assertGreater(orders['bid_price'], self.mid_price - expected_half_spread * 2) # Overall spread shifted up
+
+    def test_time_decay(self):
+        """Test how quotes change as time approaches the end of the horizon, particularly reservation price."""
+        config = AvellanedaStoikovConfig(
+            gamma=0.1, sigma=0.01, k=1.0, time_horizon_seconds=3600.0, min_spread=0.0001
+        )
+        strategy = AvellanedaStoikovStrategy(config)
+        market_data = {'mid_price': self.mid_price}
+        current_inventory = 10.0 # Positive inventory
+
+        # At start (t=0)
+        orders_start = strategy.generate_orders(market_data, current_inventory, 0.0)
+        
+        # Halfway (t=T/2)
+        orders_half = strategy.generate_orders(market_data, current_inventory, config.time_horizon_seconds / 2)
+        
+        # Near end (t=T-epsilon)
+        orders_near_end = strategy.generate_orders(market_data, current_inventory, config.time_horizon_seconds - 1.0) # 1 second left
+
+        # Expect inventory risk adjustment to decrease as time_remaining decreases.
+        # With q > 0, reservation_price = S_t - q * (term), so (q * term) decreases,
+        # which means reservation_price increases (moves closer to mid_price).
+        res_price_start = (orders_start['bid_price'] + orders_start['ask_price']) / 2
+        res_price_half = (orders_half['bid_price'] + orders_half['ask_price']) / 2
+        res_price_near_end = (orders_near_end['bid_price'] + orders_near_end['ask_price']) / 2
+
+        self.assertGreater(res_price_half, res_price_start)
+        self.assertGreater(res_price_near_end, res_price_half)
+        
+        # The half-spread (delta_A) itself does not depend on time (T-t) in this formulation.
+        # So the *total spread* (ask - bid) should remain constant (unless min_spread affects it).
+        spread_start = orders_start['ask_price'] - orders_start['bid_price']
+        spread_half = orders_half['ask_price'] - orders_half['bid_price']
+        spread_near_end = orders_near_end['ask_price'] - orders_near_end['bid_price']
+        
+        self.assertAlmostEqual(spread_start, spread_half, places=8)
+        self.assertAlmostEqual(spread_half, spread_near_end, places=8)
+
+    def test_end_of_horizon_positive_inventory(self):
+        """Test behavior at the very end of the horizon with positive inventory."""
+        config = self.default_config
+        strategy = AvellanedaStoikovStrategy(config)
+        market_data = {'mid_price': self.mid_price}
+        current_inventory = 5.0
+        
+        orders_end = strategy.generate_orders(market_data, current_inventory, config.time_horizon_seconds)
+        self.assertIsNone(orders_end['bid_price'])
+        self.assertAlmostEqual(orders_end['ask_price'], self.mid_price + config.min_spread)
+        self.assertAlmostEqual(orders_end['ask_amount'], current_inventory)
+        self.assertEqual(orders_end['bid_amount'], 0.0) # No bid to liquidate positive inventory
+
+    def test_end_of_horizon_negative_inventory(self):
+        """Test behavior at the very end of the horizon with negative inventory."""
+        config = self.default_config
+        strategy = AvellanedaStoikovStrategy(config)
+        market_data = {'mid_price': self.mid_price}
+        current_inventory = -5.0
+        
+        orders_end = strategy.generate_orders(market_data, current_inventory, config.time_horizon_seconds)
+        self.assertIsNone(orders_end['ask_price'])
+        self.assertAlmostEqual(orders_end['bid_price'], self.mid_price - config.min_spread)
+        self.assertAlmostEqual(orders_end['bid_amount'], abs(current_inventory))
+        self.assertEqual(orders_end['ask_amount'], 0.0)
+
+    def test_end_of_horizon_zero_inventory(self):
+        """Test behavior at the very end of the horizon with zero inventory."""
+        config = self.default_config
+        strategy = AvellanedaStoikovStrategy(config)
+        market_data = {'mid_price': self.mid_price}
+        current_inventory = 0.0
+        
+        orders_end = strategy.generate_orders(market_data, current_inventory, config.time_horizon_seconds)
+        self.assertIsNone(orders_end['bid_price'])
+        self.assertIsNone(orders_end['ask_price'])
+        self.assertEqual(orders_end['bid_amount'], 0.0)
+        self.assertEqual(orders_end['ask_amount'], 0.0)
+
+    def test_invalid_market_data(self):
+        """Test with missing mid_price in market_data."""
+        strategy = AvellanedaStoikovStrategy(self.default_config)
+        market_data = {} # Missing mid_price
+        current_inventory = 0.0
+        current_time = 0.0
+        with self.assertRaises(ValueError):
+            strategy.generate_orders(market_data, current_inventory, current_time)
+
+    def test_config_validation(self):
+        """Test that invalid config parameters raise errors during initialization."""
+        with self.assertRaises(ValueError):
+            AvellanedaStoikovStrategy(AvellanedaStoikovConfig(gamma=0)) # gamma <= 0
+        with self.assertRaises(ValueError):
+            AvellanedaStoikovStrategy(AvellanedaStoikovConfig(sigma=-0.01)) # sigma < 0
+        with self.assertRaises(ValueError):
+            AvellanedaStoikovStrategy(AvellanedaStoikovConfig(k=0)) # k <= 0
+        with self.assertRaises(ValueError):
+            AvellanedaStoikovStrategy(AvellanedaStoikovConfig(time_horizon_seconds=0)) # T <= 0
+        with self.assertRaises(ValueError):
+            AvellanedaStoikovStrategy(AvellanedaStoikovConfig(min_spread=-0.001)) # min_spread < 0
+        with self.assertRaises(ValueError):
+            AvellanedaStoikovStrategy(AvellanedaStoikovConfig(order_size=0)) # order_size <= 0
+        with self.assertRaises(ValueError):
+            AvellanedaStoikovStrategy(AvellanedaStoikovConfig(max_inventory=-1)) # max_inventory < 0
+        
+        # Test current_time validation during order generation
+        strategy = AvellanedaStoikovStrategy(self.default_config)
+        market_data = {'mid_price': self.mid_price}
+        with self.assertRaises(ValueError):
+            strategy.generate_orders(market_data, 0, -1.0) # current_time < 0
+
+    def test_min_spread_enforcement(self):
+        """Test that min_spread is enforced when the theoretical spread is smaller."""
+        # Configure parameters such that the optimal_half_spread would be very small
+        config_tight_spread = AvellanedaStoikovConfig(
+            gamma=100.0, # High gamma
+            sigma=0.001,
+            k=10000.0, # High k
+            time_horizon_seconds=3600.0,
+            min_spread=0.01 # Set a significant min_spread
+        )
+        strategy = AvellanedaStoikovStrategy(config_tight_spread)
+        market_data = {'mid_price': self.mid_price}
+        current_inventory = 0.0
+        current_time = 0.0
+
+        orders = strategy.generate_orders(market_data, current_inventory, current_time)
+
+        # Theoretical half spread without min_spread:
+        # (1/100) * log(1 + 100 / 10000) = 0.01 * log(1.01) approx 0.01 * 0.00995033 = 0.0000995033
+        # This is much smaller than min_spread=0.01.
+        # So, the effective half-spread should be min_spread.
+        
+        self.assertAlmostEqual(orders['ask_price'] - orders['bid_price'], 2 * config_tight_spread.min_spread, places=8)
+        self.assertAlmostEqual(orders['ask_price'], self.mid_price + config_tight_spread.min_spread, places=8)
+        self.assertAlmostEqual(orders['bid_price'], self.mid_price - config_tight_spread.min_spread, places=8)
+    
+    def test_max_inventory_exceeded(self):
+        """Test behavior when max_inventory is exceeded, triggering liquidation orders."""
+        config = self.default_config
+        strategy = AvellanedaStoikovStrategy(config)
+        market_data = {'mid_price': self.mid_price}
+
+        # Test current_inventory > max_inventory (long excess)
+        current_inventory = config.max_inventory + 5
+        orders = strategy.generate_orders(market_data, current_inventory, 0.0)
+        self.assertIsNone(orders['bid_price'])
+        self.assertAlmostEqual(orders['ask_price'], self.mid_price + config.min_spread) # Liquidate at mid + min_spread
+        self.assertAlmostEqual(orders['ask_amount'], 5.0) # Only liquidate the excess
+        self.assertEqual(orders['bid_amount'], 0.0)
+
+        # Test current_inventory < -max_inventory (short excess)
+        current_inventory = -(config.max_inventory + 7)
+        orders = strategy.generate_orders(market_data, current_inventory, 0.0)
+        self.assertIsNone(orders['ask_price'])
+        self.assertAlmostEqual(orders['bid_price'], self.mid_price - config.min_spread) # Liquidate at mid - min_spread
+        self.assertAlmostEqual(orders['bid_amount'], 7.0) # Only liquidate the excess
+        self.assertEqual(orders['ask_amount'], 0.0)
+
+        # Test with current_inventory exactly at max_inventory (should behave normally)
+        current_inventory = float(config.max_inventory)
+        orders_at_max = strategy.generate_orders(market_data, current_inventory, 0.0)
+        self.assertIsNotNone(orders_at_max['bid_price'])
+        self.assertIsNotNone(orders_at_max['ask_price'])
+        self.assertEqual(orders_at_max['bid_amount'], config.order_size)
+        self.assertEqual(orders_at_max['ask_amount'], config.order_size)
+        # Ensure it's following the strategy logic, not the liquidation logic
+        expected_time_remaining = config.time_horizon_seconds - 0.0
+        expected_inventory_risk_adjustment = current_inventory * config.gamma * config.sigma**2 * expected_time_remaining
+        expected_reservation_price = self.mid_price - expected_inventory_risk_adjustment
+        expected_half_spread = (1 / config.gamma) * math.log(1 + config.gamma / config.k)
+        expected_half_spread = max(expected_half_spread, config.min_spread)
+        self.assertAlmostEqual(orders_at_max['bid_price'], expected_reservation_price - expected_half_spread)
+        self.assertAlmostEqual(orders_at_max['ask_price'], expected_reservation_price + expected_half_spread)
+


### PR DESCRIPTION
Closes #8

## What changed
This fix implements the Avellaneda-Stoikov market-making strategy, including its core logic for reservation price and optimal spread, configurable parameters with sensible defaults, comprehensive unit tests, and detailed documentation.

## Files modified
- `src/agents/strategy.py`
- `src/agents/strategies/__init__.py`
- `src/agents/strategies/avellaneda_stoikov.py`
- `tests/unit/agents/strategies/test_avellaneda_stoikov.py`
- `src/agents/__init__.py`

---
*Draft PR — please review before merging.*