### PR TITLE
Add Uniswap V3 WebSocket swap price parsing

### DIFF
--- a/src/connectors/websocket_feed.py
+++ b/src/connectors/websocket_feed.py
@@ -11,14 +11,19 @@ Falls back to polling if WebSocket connection fails.
 import asyncio
 import json
 import logging
-from dataclasses import dataclass, field
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, getcontext
 from typing import Callable, Optional
 import websockets
 
 from src.oracle.price_feed import BasePriceFeed, PricePoint
 
 logger = logging.getLogger(__name__)
+
+UNISWAP_V3_SWAP_TOPIC = "0xc42079f94a6350d7e6235f29174924f928cc2ac818ebdf2fb8b6a4a6a6d9b84d"
+UNISWAP_V3_Q192 = Decimal(2) ** 192
+getcontext().prec = 80
 
 
 @dataclass
@@ -29,6 +34,11 @@ class WebSocketConfig:
     ping_interval: float = 20.0
     reconnect_delay: float = 5.0
     max_reconnects: int = 10
+    asset: Optional[str] = None
+    source: str = "websocket"
+    token0_decimals: int = 18
+    token1_decimals: int = 18
+    invert_price: bool = False
 
 
 class WebSocketPriceFeed(BasePriceFeed):
@@ -114,7 +124,7 @@ class WebSocketPriceFeed(BasePriceFeed):
         """Parse incoming WebSocket message and update price cache."""
         try:
             data = json.loads(message)
-            price_point = self._parse_price(data)
+            price_point = self._parse_uniswap_v3_swap(data) or self._parse_price(data)
             if price_point:
                 self._update_price(price_point)
         except json.JSONDecodeError:
@@ -145,8 +155,62 @@ class WebSocketPriceFeed(BasePriceFeed):
             price=float(price),
             currency=data.get("currency", "USD"),
             source=data.get("source", "websocket"),
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             confidence=data.get("confidence", 0.95),
+        )
+
+    def _parse_uniswap_v3_swap(self, data: dict) -> Optional[PricePoint]:
+        """Parse an Ethereum log subscription payload for a Uniswap V3 Swap event.
+
+        The Swap event's data payload contains five ABI-encoded fields:
+        ``amount0``, ``amount1``, ``sqrtPriceX96``, ``liquidity``, and ``tick``.
+        The live pool price is derived from ``sqrtPriceX96`` as token1 per token0,
+        adjusted by token decimal differences. Use ``invert_price=True`` when the
+        configured asset should be represented as token0 per token1.
+        """
+        params = data.get("params") or {}
+        result = params.get("result") if isinstance(params, dict) else None
+        if not isinstance(result, dict):
+            return None
+
+        topics = result.get("topics") or []
+        if not topics or str(topics[0]).lower() != UNISWAP_V3_SWAP_TOPIC:
+            return None
+
+        raw_data = result.get("data")
+        if not isinstance(raw_data, str) or not raw_data.startswith("0x"):
+            return None
+        encoded = raw_data[2:]
+        if len(encoded) < 64 * 5:
+            return None
+
+        try:
+            sqrt_price_x96 = int(encoded[64 * 2:64 * 3], 16)
+        except ValueError:
+            return None
+        if sqrt_price_x96 <= 0:
+            return None
+
+        raw_price = (Decimal(sqrt_price_x96) * Decimal(sqrt_price_x96)) / UNISWAP_V3_Q192
+        decimal_adjustment = Decimal(10) ** (self.config.token1_decimals - self.config.token0_decimals)
+        price = raw_price * decimal_adjustment
+        if self.config.invert_price:
+            if price == 0:
+                return None
+            price = Decimal(1) / price
+
+        block_timestamp = data.get("timestamp") or result.get("timestamp")
+        timestamp = datetime.now(timezone.utc)
+        if isinstance(block_timestamp, (int, float)):
+            timestamp = datetime.fromtimestamp(block_timestamp, tz=timezone.utc)
+
+        return PricePoint(
+            asset=self.config.asset or result.get("address", "UNISWAP-V3"),
+            price=float(price),
+            currency="USD",
+            source="uniswap-v3",
+            timestamp=timestamp,
+            confidence=0.98,
         )
 
     def _update_price(self, point: PricePoint):
@@ -178,28 +242,52 @@ class WebSocketPriceFeed(BasePriceFeed):
         return self._reconnect_count
 
 
-def create_uniswap_ws_config(pool_address: str, chain: str = "ethereum") -> WebSocketConfig:
-    """Create WebSocket config for Uniswap V3 pool swap events."""
+def create_uniswap_ws_config(
+    pool_address: str,
+    chain: str = "ethereum",
+    *,
+    provider_key: Optional[str] = None,
+    asset: Optional[str] = None,
+    token0_decimals: int = 18,
+    token1_decimals: int = 18,
+    invert_price: bool = False,
+) -> WebSocketConfig:
+    """Create WebSocket config for Uniswap V3 pool swap events.
+
+    Args:
+        pool_address: Uniswap V3 pool contract address.
+        chain: Supported chain key (``ethereum``, ``arbitrum``, or ``base``).
+        provider_key: Optional Alchemy API key appended to the WebSocket URL.
+        asset: Asset symbol/pair to attach to parsed price points.
+        token0_decimals: Decimals for the pool's token0.
+        token1_decimals: Decimals for the pool's token1.
+        invert_price: Return token0/token1 instead of token1/token0.
+    """
     ws_urls = {
-        "ethereum": "wss://eth-mainnet.g.alchemy.com/v2/",
-        "arbitrum": "wss://arb-mainnet.g.alchemy.com/v2/",
-        "base": "wss://base-mainnet.g.alchemy.com/v2/",
+        "ethereum": "wss://eth-mainnet.g.alchemy.com/v2",
+        "arbitrum": "wss://arb-mainnet.g.alchemy.com/v2",
+        "base": "wss://base-mainnet.g.alchemy.com/v2",
     }
+    base_url = ws_urls.get(chain, ws_urls["ethereum"])
+    url = f"{base_url}/{provider_key}" if provider_key else base_url
 
     return WebSocketConfig(
-        url=ws_urls.get(chain, ws_urls["ethereum"]),
+        url=url,
         subscription_msg={
             "method": "eth_subscribe",
             "params": [
                 "logs",
                 {
                     "address": pool_address,
-                    "topics": [
-                        "0xc42079f94a6350d7e6235f29174924f928cc2ac818ebdf2fb8b6a4a6a6d9b84d"
-                    ]
+                    "topics": [UNISWAP_V3_SWAP_TOPIC]
                 }
             ],
             "id": 1,
             "jsonrpc": "2.0",
         },
+        asset=asset,
+        source="uniswap-v3",
+        token0_decimals=token0_decimals,
+        token1_decimals=token1_decimals,
+        invert_price=invert_price,
     )

--- a/tests/unit/connectors/test_websocket_feed.py
+++ b/tests/unit/connectors/test_websocket_feed.py
@@ -4,10 +4,14 @@ import asyncio
 import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+from decimal import Decimal
+from datetime import datetime, timezone
+
 from src.connectors.websocket_feed import (
     WebSocketPriceFeed,
     WebSocketConfig,
     create_uniswap_ws_config,
+    UNISWAP_V3_SWAP_TOPIC,
 )
 from src.oracle.price_feed import PricePoint
 
@@ -167,10 +171,23 @@ class TestConnectionState:
 
 class TestUniswapConfig:
     def test_create_uniswap_ws_config(self):
-        config = create_uniswap_ws_config("0x1234", "ethereum")
-        assert "eth-mainnet" in config.url
+        config = create_uniswap_ws_config(
+            "0x1234",
+            "ethereum",
+            provider_key="alchemy-key",
+            asset="ETH/USDC",
+            token0_decimals=18,
+            token1_decimals=6,
+            invert_price=True,
+        )
+        assert config.url == "wss://eth-mainnet.g.alchemy.com/v2/alchemy-key"
+        assert config.asset == "ETH/USDC"
+        assert config.token0_decimals == 18
+        assert config.token1_decimals == 6
+        assert config.invert_price is True
         assert config.subscription_msg["method"] == "eth_subscribe"
         assert "logs" in config.subscription_msg["params"]
+        assert config.subscription_msg["params"][1]["topics"] == [UNISWAP_V3_SWAP_TOPIC]
 
     def test_create_uniswap_ws_config_arbitrum(self):
         config = create_uniswap_ws_config("0x5678", "arbitrum")
@@ -195,3 +212,74 @@ class TestMessageHandling:
     async def test_handle_missing_fields(self, feed):
         msg = json.dumps({"foo": "bar"})
         await feed._handle_message(msg)  # Should not raise, no price set
+        assert feed.get_price("ETH/USD") is None
+
+
+# ── Uniswap V3 swap event parsing ─────────────────────────────────────────────
+
+def _uniswap_swap_message(sqrt_price_x96: int, timestamp: int = 1_700_000_000) -> dict:
+    # Five ABI words: amount0, amount1, sqrtPriceX96, liquidity, tick.
+    words = [0, 0, sqrt_price_x96, 0, 0]
+    return {
+        "jsonrpc": "2.0",
+        "method": "eth_subscription",
+        "params": {
+            "subscription": "0xsub",
+            "result": {
+                "address": "0xpool",
+                "topics": [UNISWAP_V3_SWAP_TOPIC],
+                "data": "0x" + "".join(f"{word:064x}" for word in words),
+                "timestamp": timestamp,
+            },
+        },
+    }
+
+
+class TestUniswapV3SwapParsing:
+    def test_parse_uniswap_v3_swap_event(self):
+        config = WebSocketConfig(
+            url="ws://localhost:8080",
+            subscription_msg={},
+            asset="ETH/USDC",
+            source="uniswap-v3",
+            token0_decimals=18,
+            token1_decimals=6,
+            invert_price=True,
+        )
+        feed = WebSocketPriceFeed(config)
+        # token1/token0 raw price = 2000e-12 after decimal adjustment,
+        # so inverted ETH/USDC price is 500,000,000 when sqrt is sqrt(2000)*Q96.
+        sqrt_price_x96 = int((Decimal(2000).sqrt()) * (Decimal(2) ** 96))
+        point = feed._parse_uniswap_v3_swap(_uniswap_swap_message(sqrt_price_x96))
+        assert point is not None
+        assert point.asset == "ETH/USDC"
+        assert point.source == "uniswap-v3"
+        assert point.confidence == 0.98
+        assert point.timestamp == datetime.fromtimestamp(1_700_000_000, tz=timezone.utc)
+        assert point.price == pytest.approx(500_000_000, rel=1e-12)
+
+    def test_parse_uniswap_v3_swap_without_inversion(self):
+        config = WebSocketConfig(url="ws://localhost:8080", subscription_msg={})
+        feed = WebSocketPriceFeed(config)
+        sqrt_price_x96 = int(Decimal(2).sqrt() * (Decimal(2) ** 96))
+        point = feed._parse_uniswap_v3_swap(_uniswap_swap_message(sqrt_price_x96))
+        assert point is not None
+        assert point.asset == "0xpool"
+        assert point.price == pytest.approx(2.0, rel=1e-15)
+
+    def test_parse_uniswap_v3_swap_ignores_non_swap_logs(self, feed):
+        message = _uniswap_swap_message(int(Decimal(2) ** 96))
+        message["params"]["result"]["topics"] = ["0xdeadbeef"]
+        assert feed._parse_uniswap_v3_swap(message) is None
+
+    @pytest.mark.asyncio
+    async def test_handle_message_updates_cache_from_uniswap_swap(self):
+        config = WebSocketConfig(
+            url="ws://localhost:8080",
+            subscription_msg={},
+            asset="TOKEN1/TOKEN0",
+        )
+        feed = WebSocketPriceFeed(config)
+        message = _uniswap_swap_message(int(Decimal(2) ** 96))
+        await feed._handle_message(json.dumps(message))
+        assert feed.get_price("TOKEN1/TOKEN0").price == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

Adds concrete Uniswap V3 Swap-event parsing to the WebSocket price feed so issue #4 can turn `eth_subscribe` pool logs into live `PricePoint` updates instead of only accepting generic JSON price messages.

## What changed

- Extended `WebSocketConfig` with optional asset metadata and token decimal/inversion settings for DEX pool pricing.
- Added `UNISWAP_V3_SWAP_TOPIC` and parser support for Ethereum log subscription payloads.
- Derives live pool price from `sqrtPriceX96`, adjusts for token decimal differences, and optionally inverts the pair direction.
- Updates `_handle_message()` to prefer Uniswap V3 Swap parsing before falling back to generic websocket price messages.
- Expanded tests for config generation, Swap-event decoding, ignored non-Swap logs, and cache updates from `eth_subscription` payloads.

## Verification

```bash
.venv/bin/python -m pytest -q
```

Result: `95 passed, 2 skipped`.

Closes #4
