### PR TITLE
docs: fix incorrect `cd deploy` in CONTRIBUTING.md contracts setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,6 @@ python -m src.agents.rwa_market_maker --simulate
 
 ### Contracts
 ```bash
-cd deploy
 npm install
 npx hardhat compile
 npx hardhat test


### PR DESCRIPTION
### What
Remove the erroneous `cd deploy` line from the Contracts setup block in `CONTRIBUTING.md`.

### Why
`package.json` (and therefore Hardhat) lives at the repo root, not inside `deploy/`. Running `cd deploy` before `npm install` would leave contributors in the wrong directory with no `package.json`, causing an immediate failure. The README's Quick Start already runs these commands from the root correctly.

Small, scoped fix from kcolbchain contrib-bot.