### PR TITLE
docs: add missing --config flag to CONTRIBUTING quick-start command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ git clone https://github.com/YOUR_USERNAME/meridian.git
 cd meridian
 pip install -r requirements.txt
 python -m pytest tests/
-python -m src.agents.rwa_market_maker --simulate
+python -m src.agents.rwa_market_maker --config config/default.yaml --simulate
 ```
 
 ### Contracts


### PR DESCRIPTION
### What
Add `--config config/default.yaml` to the agent invocation in `CONTRIBUTING.md`.

### Why
The README's Quick Start shows `python -m src.agents.rwa_market_maker --config config/default.yaml --simulate`, but `CONTRIBUTING.md` omits the `--config` flag. A contributor following CONTRIBUTING.md will hit a missing-config error on their very first run.

Small, scoped fix from kcolbchain contrib-bot.