### PR TITLE
docs: add missing --config flag to CONTRIBUTING quick-start

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ git clone https://github.com/YOUR_USERNAME/meridian.git
 cd meridian
 pip install -r requirements.txt
 python -m pytest tests/
-python -m src.agents.rwa_market_maker --simulate
+python -m src.agents.rwa_market_maker --config config/default.yaml --simulate
 ```
 
 ### Contracts


### PR DESCRIPTION
Closes #46

Adds `--config config/default.yaml` to the agent invocation in `CONTRIBUTING.md` to match the README Quick Start. Prevents contributors from hitting a missing-config error on their first run.